### PR TITLE
[markdown-Refactor] markdown의 type설정

### DIFF
--- a/src/pages/detail/components/MarkdownWithHighlight.tsx
+++ b/src/pages/detail/components/MarkdownWithHighlight.tsx
@@ -1,6 +1,15 @@
+import { HTMLAttributes, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+interface CodeProps extends HTMLAttributes<HTMLElement> {
+  inline?: boolean;
+  node?: unknown; // 필요시 구체화 가능
+  className?: string;
+  children?: ReactNode; // react-markdown은 배열도 올 수 있어요
+}
 
 export const MarkdownWithHighlight = ({ content }: { content: string }) => {
   return (
@@ -8,8 +17,9 @@ export const MarkdownWithHighlight = ({ content }: { content: string }) => {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          code({ inline, className, children, ...props }) {
+          code({ inline, className, children, ...props }: CodeProps) {
             const match = /language-(\w+)/.exec(className || "");
+            // 1) 인라인 코드면 <code>로만 렌더(하이라이트 X)
             if (inline || !match) {
               return (
                 <code className={className} {...props}>
@@ -17,11 +27,12 @@ export const MarkdownWithHighlight = ({ content }: { content: string }) => {
                 </code>
               );
             }
+            // 2) 블록 코드면 SyntaxHighlighter 사용
             return (
               <SyntaxHighlighter
-                language={match[1]}
                 PreTag="div"
-                {...props}
+                language={match[1]}
+                style={oneDark}
               >
                 {String(children).replace(/\n$/, "")}
               </SyntaxHighlighter>
@@ -46,3 +57,38 @@ export const MarkdownWithHighlight = ({ content }: { content: string }) => {
     </div>
   );
 };
+
+//const components = {
+//   code({ inline, className, children, ...props }: CodeProps) {
+//     const match = /language-(\w+)/.exec(className || "");
+//     // 1) 인라인 코드면 <code>로만 렌더(하이라이트 X)
+//     if (inline || !match) {
+//       return (
+//         <code className={className} {...props}>
+//           {children}
+//         </code>
+//       );
+//     }
+//     // 2) 블록 코드면 SyntaxHighlighter 사용
+//     return (
+//       <SyntaxHighlighter PreTag="div" language={match[1]} style={oneDark}>
+//         {String(children).replace(/\n$/, "")}
+//       </SyntaxHighlighter>
+//     );
+//   },
+//   a({ href, children, ...props }) {
+//     return (
+//       <a href={href} target="_blank" rel="noreferrer noopener" {...props}>
+//         {children}
+//       </a>
+//     );
+//   }
+// };
+
+// export const MarkdownWithHighlight = ({ content }: { content: string }) => {
+//   return (
+//     <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+//       {content}
+//     </ReactMarkdown>
+//   );
+// };


### PR DESCRIPTION
-markdown의 components속성을 커스텀하기 위해 inline에 추가한 내용들의 타입을 지정해줌 -code의 inline타입을 지정했어야 했는데 import하여 타입을 가져올 수 없어 임시로 타입 지정하여 사용 -components의 분리를 시도하였으나 ReactMarkdown의 자동 타입 추론이 사라져서 그냥 inline으로 하기로함